### PR TITLE
Refactor welcome pages

### DIFF
--- a/app/controllers/welcomes_controller.rb
+++ b/app/controllers/welcomes_controller.rb
@@ -1,5 +1,74 @@
 class WelcomesController < ApplicationController
+  before_action :set_welcome, only: [:show, :edit, :update, :destroy]
+
+  # GET /welcomes
+  # GET /welcomes.json
   def index
     @welcomes = Welcome.all
   end
+
+  # GET /welcomes/1
+  # GET /welcomes/1.json
+  def show
+  end
+
+  # GET /welcomes/new
+  def new
+    @welcome = Welcome.new
+  end
+
+  # GET /welcomes/1/edit
+  def edit
+  end
+
+  # POST /welcomes
+  # POST /welcomes.json
+  def create
+    @welcome = Welcome.new(welcome_params)
+
+    respond_to do |format|
+      if @welcome.save
+        format.html { redirect_to @welcome, notice: 'Welcome was successfully created.' }
+        format.json { render :show, status: :created, location: @welcome }
+      else
+        format.html { render :new }
+        format.json { render json: @welcome.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /welcomes/1
+  # PATCH/PUT /welcomes/1.json
+  def update
+    respond_to do |format|
+      if @welcome.update(welcome_params)
+        format.html { redirect_to @welcome, notice: 'Welcome was successfully updated.' }
+        format.json { render :show, status: :ok, location: @welcome }
+      else
+        format.html { render :edit }
+        format.json { render json: @welcome.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /welcomes/1
+  # DELETE /welcomes/1.json
+  def destroy
+    @welcome.destroy
+    respond_to do |format|
+      format.html { redirect_to welcomes_url, notice: 'Welcome was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_welcome
+      @welcome = Welcome.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def welcome_params
+      params.require(:welcome).permit(:path, :title)
+    end
 end

--- a/app/views/welcomes/_form.html.erb
+++ b/app/views/welcomes/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: welcome, local: true) do |form| %>
+  <% if welcome.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(welcome.errors.count, "error") %> prohibited this welcome from being saved:</h2>
+
+      <ul>
+        <% welcome.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :path %>
+    <%= form.text_field :path %>
+  </div>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/welcomes/_welcome.json.jbuilder
+++ b/app/views/welcomes/_welcome.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! welcome, :id, :path, :title, :created_at, :updated_at
+json.url welcome_url(welcome, format: :json)

--- a/app/views/welcomes/edit.html.erb
+++ b/app/views/welcomes/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Welcome</h1>
+
+<%= render 'form', welcome: @welcome %>
+
+<%= link_to 'Show', @welcome %> |
+<%= link_to 'Back', welcomes_path %>

--- a/app/views/welcomes/index.html.erb
+++ b/app/views/welcomes/index.html.erb
@@ -5,7 +5,8 @@
 <table>
   <thead>
     <tr>
-      <th>Links</th>
+      <th>Path</th>
+      <th>Title</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -13,8 +14,16 @@
   <tbody>
     <% @welcomes.each do |welcome| %>
       <tr>
-        <td><%= link_to welcome.title, public_send(:"#{welcome.link}_path") %></td>
+        <td><%= link_to welcome.path, public_send(:"#{welcome.path}_path") %></td>
+        <td><%= welcome.title %></td>
+        <td><%= link_to 'Show', welcome %></td>
+        <td><%= link_to 'Edit', edit_welcome_path(welcome) %></td>
+        <td><%= link_to 'Destroy', welcome, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
+
+<br>
+
+<%= link_to 'New Welcome', new_welcome_path %>

--- a/app/views/welcomes/index.json.jbuilder
+++ b/app/views/welcomes/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @welcomes, partial: "welcomes/welcome", as: :welcome

--- a/app/views/welcomes/new.html.erb
+++ b/app/views/welcomes/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Welcome</h1>
+
+<%= render 'form', welcome: @welcome %>
+
+<%= link_to 'Back', welcomes_path %>

--- a/app/views/welcomes/show.html.erb
+++ b/app/views/welcomes/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Path:</strong>
+  <%= @welcome.path %>
+</p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @welcome.title %>
+</p>
+
+<%= link_to 'Edit', edit_welcome_path(@welcome) %> |
+<%= link_to 'Back', welcomes_path %>

--- a/app/views/welcomes/show.json.jbuilder
+++ b/app/views/welcomes/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "welcomes/welcome", welcome: @welcome

--- a/db/migrate/20200610220410_create_welcomes.rb
+++ b/db/migrate/20200610220410_create_welcomes.rb
@@ -1,7 +1,7 @@
 class CreateWelcomes < ActiveRecord::Migration[6.0]
   def change
     create_table :welcomes do |t|
-      t.string :link
+      t.string :path
       t.string :title
 
       t.timestamps

--- a/db/migrate/20200610220411_add_links_to_welcome.rb
+++ b/db/migrate/20200610220411_add_links_to_welcome.rb
@@ -8,7 +8,7 @@ class AddLinksToWelcome < ActiveRecord::Migration[6.0]
     )
 
     resources.each do |resource|
-      Welcome.new(link: resource, title: resource.titleize).save
+      Welcome.new(path: resource, title: resource.titleize).save
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_10_203058) do
+ActiveRecord::Schema.define(version: 2020_06_10_220411) do
 
   create_table "items", force: :cascade do |t|
     t.string "name"
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 2020_06_10_203058) do
   end
 
   create_table "welcomes", force: :cascade do |t|
-    t.string "link"
+    t.string "path"
     t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/test/controllers/welcomes_controller_test.rb
+++ b/test/controllers/welcomes_controller_test.rb
@@ -1,7 +1,48 @@
 require 'test_helper'
 
 class WelcomesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @welcome = welcomes(:one)
+  end
+
+  test "should get index" do
+    get welcomes_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_welcome_url
+    assert_response :success
+  end
+
+  test "should create welcome" do
+    assert_difference('Welcome.count') do
+      post welcomes_url, params: { welcome: { path: @welcome.path, title: @welcome.title } }
+    end
+
+    assert_redirected_to welcome_url(Welcome.last)
+  end
+
+  test "should show welcome" do
+    get welcome_url(@welcome)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_welcome_url(@welcome)
+    assert_response :success
+  end
+
+  test "should update welcome" do
+    patch welcome_url(@welcome), params: { welcome: { path: @welcome.path, title: @welcome.title } }
+    assert_redirected_to welcome_url(@welcome)
+  end
+
+  test "should destroy welcome" do
+    assert_difference('Welcome.count', -1) do
+      delete welcome_url(@welcome)
+    end
+
+    assert_redirected_to welcomes_url
+  end
 end

--- a/test/fixtures/welcomes.yml
+++ b/test/fixtures/welcomes.yml
@@ -1,7 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  link: MyString
+  path: MyString
+  title: MyString
 
 two:
-  link: MyString
+  path: MyString
+  title: MyString

--- a/test/system/welcomes_test.rb
+++ b/test/system/welcomes_test.rb
@@ -1,0 +1,45 @@
+require "application_system_test_case"
+
+class WelcomesTest < ApplicationSystemTestCase
+  setup do
+    @welcome = welcomes(:one)
+  end
+
+  test "visiting the index" do
+    visit welcomes_url
+    assert_selector "h1", text: "Welcomes"
+  end
+
+  test "creating a Welcome" do
+    visit welcomes_url
+    click_on "New Welcome"
+
+    fill_in "Path", with: @welcome.path
+    fill_in "Title", with: @welcome.title
+    click_on "Create Welcome"
+
+    assert_text "Welcome was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Welcome" do
+    visit welcomes_url
+    click_on "Edit", match: :first
+
+    fill_in "Path", with: @welcome.path
+    fill_in "Title", with: @welcome.title
+    click_on "Update Welcome"
+
+    assert_text "Welcome was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Welcome" do
+    visit welcomes_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Welcome was successfully destroyed"
+  end
+end


### PR DESCRIPTION
This commit refactors the welcome page. Instead of just generating the
resources, a scaffold is generated instead. A migration is added to
prepopulate the various pages, and as new models are added, the path and
title can be added through the UI.