### PR TITLE
Only load hex show page js on hex show page

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,8 +9,6 @@ require("@rails/activestorage").start()
 import 'bootstrap'
 require("channels")
 
-require('packs/hexes')
-
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.

--- a/app/views/hexes/show.html.erb
+++ b/app/views/hexes/show.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_pack_tag 'hexes/index', 'data-turbolinks-track': 'reload' %>
 <p id="notice"><%= notice %></p>
 
 <p>


### PR DESCRIPTION
This commit removes the hex show page JS and adds a
`javascript_pack_tag` helper to the hex show page, since that JS is
specific to the page.