### PR TITLE
Update Dockerfile, compose, and deploy script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,4 @@ RUN bundle install
 RUN rails webpacker:install
 RUN rails db:setup
 
-CMD rails s -p 35001 -b 0.0.0.0
-
 EXPOSE 35001

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,3 +5,4 @@ services:
     image: manik1235/story_time:dev
     ports:
       - '35002:35001'
+    command: ["rails", "s", "-p", "35001", "-b", "0.0.0.0"]

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -7,6 +7,7 @@ services:
       - '35003:35001'
     volumes:
       - '.:/app'
+    command: ["rails", "s", "-p", "35001", "-b", "0.0.0.0"]
 
   cmd:
     build: .

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,3 +5,7 @@ services:
     image: manik1235/story_time:latest
     ports:
       - '35001:35001'
+    command: ["rails", "s", "-p", "35001", "-b", "0.0.0.0"]
+
+  cmd:
+    image: manik1235/story_time:latest

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,4 +4,4 @@ git checkout master
 git pull
 docker image pull manik1235/story_time:latest
 docker-compose down
-docker-compose up -d
+docker-compose -f docker-compose.prod.yml up -d


### PR DESCRIPTION
This commit moves the command to start the server from the Dockerfile to
the docker-compose files. This facilitates the addition of the `cmd`
service, which can be used to run one-off commands in the context of the
app, without using the app service.

The deploy script for deploying the production server is updated to use
the proper docker-compose file as well.

All servers now run on port 35001, and the docker-compose file is
responsible for mapping that to the proper port based on the
environment.