### PR TITLE
Fix deploy script to use proper docker-compose file

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,5 +3,5 @@
 git checkout master
 git pull
 docker image pull manik1235/story_time:latest
-docker-compose down
+docker-compose -f docker-compose.prod.yml down
 docker-compose -f docker-compose.prod.yml up -d


### PR DESCRIPTION
This commit fixes the deploy script to use the proper docker compose
file when calling `docker-compose down`, so that it actually stops the
container.