### PR TITLE
Fix hexes tests

### DIFF
--- a/app/views/hexes/show.html.erb
+++ b/app/views/hexes/show.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_pack_tag 'hexes/index', 'data-turbolinks-track': 'reload' %>
 <p id="notice"><%= notice %></p>
 
 <p>


### PR DESCRIPTION
This commit removes the javascript_pack_tag from the hex show page since
it does not exist.