### PR TITLE
Check yarn files before starting server

### DIFF
--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+yarn install --check-files
 rails s -p 35001 -b 0.0.0.0 -d
 bin/webpack-dev-server


### PR DESCRIPTION
This commit adds a `yarn install --check-files` command before
starting the servers. This helps prevent the issue with files being out
of date.

https://github.com/manik1235/story_time/issues/63