### PR TITLE
Implement live grid redraw

### DIFF
--- a/app/controllers/axis_controller.rb
+++ b/app/controllers/axis_controller.rb
@@ -5,9 +5,7 @@ class AxisController < ApplicationController
   # PATCH/PUT /axis/1.json
   def update
     respond_to do |format|
-      if @axis.update(axis_params)
-        format.json { render :show, status: :ok, location: @axis }
-      else
+      if !@axis.update(axis_params)
         format.json { render json: @axis.errors, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -41,10 +41,7 @@ class MapsController < ApplicationController
   # PATCH/PUT /maps/1.json
   def update
     respond_to do |format|
-      if @map.update(map_params)
-        format.html { redirect_to @map, notice: 'Map was successfully updated.' }
-        format.json { render :show, status: :ok, location: @map }
-      else
+      if !@map.update(map_params)
         format.html { render :edit }
         format.json { render json: @map.errors, status: :unprocessable_entity }
       end

--- a/app/javascript/components/axis.js
+++ b/app/javascript/components/axis.js
@@ -54,6 +54,9 @@ class Axis {
     var x0 = this._x0
     var y0 = this._y0
 
+    // Clear the old lines from the canvas
+    ctx.clearRect(0, 0, this.mapWidth, this.mapHeight)
+
     // Draw first set of lines
     this._drawDashedLines(ctx, x0, y0)
 

--- a/app/javascript/components/axis.js
+++ b/app/javascript/components/axis.js
@@ -10,13 +10,14 @@ class Axis {
 
   _addUpdateListener() {
     let elements = document.getElementsByClassName(this._selector)
+    let that = this
 
     for (let index = 0; index < elements.length; index++) {
       let element = elements[index]
       element.addEventListener('change', function(event) {
         // TODO: Use the event to selectively update the proper property
-        this._updateAxis()
-        this.drawLines(this._axisContext)
+        that._updateAxis()
+        that.drawLines(that._axisContext)
       })
     }
   }

--- a/app/javascript/components/axis.js
+++ b/app/javascript/components/axis.js
@@ -1,14 +1,14 @@
 class Axis {
   constructor(options) {
     this.name = options.name
-    this.degrees = options.degrees
-    this._xOffset = options.x_offset
-    this._y0 = options.y_offset
-    this.hexDiameter = options.hex_diameter
-    this.mapWidth = options.map_width
-    this.mapHeight = options.map_height
-    this.dashFilledLength = options.dash_filled_length
-    this.dashBlankLength = options.dash_blank_length
+    this.degrees = parseFloat(options.degrees)
+    this._xOffset = parseFloat(options.x_offset)
+    this._y0 = parseFloat(options.y_offset)
+    this.hexDiameter = parseFloat(options.hex_diameter)
+    this.mapWidth = parseFloat(options.map_width)
+    this.mapHeight = parseFloat(options.map_height)
+    this.dashFilledLength = parseFloat(options.dash_filled_length)
+    this.dashBlankLength = parseFloat(options.dash_blank_length)
     this.color = options.color
   }
 

--- a/app/javascript/components/axis.js
+++ b/app/javascript/components/axis.js
@@ -1,15 +1,47 @@
 class Axis {
-  constructor(options) {
-    this.name = options.name
-    this.degrees = parseFloat(options.degrees)
-    this._xOffset = parseFloat(options.x_offset)
-    this._y0 = parseFloat(options.y_offset)
-    this.hexDiameter = parseFloat(options.hex_diameter)
-    this.mapWidth = parseFloat(options.map_width)
-    this.mapHeight = parseFloat(options.map_height)
-    this.dashFilledLength = parseFloat(options.dash_filled_length)
-    this.dashBlankLength = parseFloat(options.dash_blank_length)
-    this.color = options.color
+  constructor(selector, ctx) {
+    this._selector = selector
+    this._axisContext = ctx
+
+    this._updateAxis()
+    this.drawLines(this._axisContext)
+    this._addUpdateListener()
+  }
+
+  _addUpdateListener() {
+    let elements = document.getElementsByClassName(this._selector)
+
+    for (let index = 0; index < elements.length; index++) {
+      let element = elements[index]
+      element.addEventListener('change', function(event) {
+        // TODO: Use the event to selectively update the proper property
+        this._updateAxis()
+        this.drawLines(this._axisContext)
+      })
+    }
+  }
+
+  _updateAxis() {
+    // Get the axis data based on the current values of all the input boxes
+    let axisElements = document.getElementsByClassName(this._selector)
+    let axisObject = {}
+
+    for (let elem of axisElements) {
+      let property = elem.getAttribute('name').replace('axis[', '').replace(']', '')
+
+      axisObject[property] = elem.value
+    }
+
+    this.name = axisObject.name
+    this.degrees = parseFloat(axisObject.degrees)
+    this._xOffset = parseFloat(axisObject.x_offset)
+    this._y0 = parseFloat(axisObject.y_offset)
+    this.hexDiameter = parseFloat(axisObject.hex_diameter)
+    this.mapWidth = parseFloat(axisObject.map_width)
+    this.mapHeight = parseFloat(axisObject.map_height)
+    this.dashFilledLength = parseFloat(axisObject.dash_filled_length)
+    this.dashBlankLength = parseFloat(axisObject.dash_blank_length)
+    this.color = axisObject.color
   }
 
   get dash() {

--- a/app/javascript/components/game_map.js
+++ b/app/javascript/components/game_map.js
@@ -26,12 +26,12 @@ class GameMap {
     this._axes
   }
 
-  get _axisContext() {
-    return document.getElementById('map-component__grid-layer').getContext('2d')
+  _axisContext(index) {
+    return document.getElementById(`${this._axisSelector(index)}`).getContext('2d')
   }
 
   _addHtmlToDom() {
-   this._element.innerHTML = this._html()
+    this._element.innerHTML = this._html
   }
 
   get _dataset() {
@@ -54,13 +54,30 @@ class GameMap {
     return document.getElementById(this._selector)
   }
 
-  _html() {
+  get _html() {
+    let html = this._mapHtml
+
+    for (let index = 0; index < parseInt(this._map.number_of_axes); index++) {
+      html += this._axisHtml(index)
+    }
+
+    return html
+  }
+
+  get _mapHtml() {
     return `
       <canvas id="map-component__map-layer" height="800" width="800"
-        style="position: absolute; left: 0; top: 0; z-index: 0;"></canvas>
-      <canvas id="map-component__grid-layer" height="800" width="800"
-        style="position: absolute; left: 0; top: 0; z-index: 1;"></canvas>
-    `
+        style="position: absolute; left: 0; top: 0; z-index: 0;"></canvas>`
+  }
+
+  _axisHtml(index) {
+      return `
+      <canvas id="${this._axisSelector(index)}" height="800" width="800"
+        style="position: absolute; left: 0; top: 0; z-index: 1;"></canvas>`
+  }
+
+  _axisSelector(index) {
+    return `map-component__axis-layer-${index}`
   }
 
   get _map() {
@@ -91,7 +108,7 @@ class GameMap {
 
       for (let index = 0; index < axisElements.length; index++) {
         let elem = axisElements[index]
-        axes.push(new Axis(elem.dataset.selector, this._axisContext))
+        axes.push(new Axis(elem.dataset.selector, this._axisContext(index)))
       }
 
       this._axesCache = axes

--- a/app/javascript/components/game_map.js
+++ b/app/javascript/components/game_map.js
@@ -22,10 +22,12 @@ class GameMap {
       document.getElementById('map-component__map-layer').getContext('2d')
     )
 
-    // Get the canvas context for the map layer and draw the grid
-    this._drawHexGrid(
-      document.getElementById('map-component__grid-layer').getContext('2d')
-    )
+    // Draw the grid axes
+    this._axes
+  }
+
+  get _axisContext() {
+    return document.getElementById('map-component__grid-layer').getContext('2d')
   }
 
   _addHtmlToDom() {
@@ -34,10 +36,6 @@ class GameMap {
 
   get _dataset() {
     return this._element.dataset
-  }
-
-  _drawHexGrid(ctx) {
-    this._axes.forEach(axis => axis.drawLines(ctx))
   }
 
   _drawMapImage(ctx) {
@@ -89,21 +87,11 @@ class GameMap {
 
     if (this._axesCache.length === 0) {
       // Get the axis data based on the current values of all the input boxes
-      let axisElements = document.getElementsByClassName('js-axis-data')
-      let axisObjects = {}
+      let axisElements = document.getElementsByClassName('js-axis-form')
 
-      for (let elem of axisElements) {
-        let property = elem.getAttribute('id').replace('axis_', '')
-        let axisId = elem.dataset.id
-
-        if (!axisObjects[axisId]) {
-          axisObjects[axisId] = {}
-        }
-        axisObjects[axisId][property] = elem.value
-      }
-
-      for (let axis in axisObjects) {
-        axes.push(new Axis(axisObjects[axis]))
+      for (let index = 0; index < axisElements.length; index++) {
+        let elem = axisElements[index]
+        axes.push(new Axis(elem.dataset.selector, this._axisContext))
       }
 
       this._axesCache = axes

--- a/app/javascript/components/game_map.js
+++ b/app/javascript/components/game_map.js
@@ -3,6 +3,8 @@ import { Axis } from './axis'
 class GameMap {
   constructor(selector) {
     this._selector = selector
+    this._axesCache = []
+    this._mapCache
   }
 
   addMap() {
@@ -27,14 +29,7 @@ class GameMap {
   }
 
   _addHtmlToDom() {
-    this._element.innerHTML = this._html()
-  }
-
-  _axes() {
-    var axes = []
-    this._map.axes.forEach(axis => axes.push(new Axis(JSON.parse(axis))))
-
-    return axes
+   this._element.innerHTML = this._html()
   }
 
   get _dataset() {
@@ -42,7 +37,7 @@ class GameMap {
   }
 
   _drawHexGrid(ctx) {
-    this._axes().forEach(axis => axis.drawLines(ctx))
+    this._axes.forEach(axis => axis.drawLines(ctx))
   }
 
   _drawMapImage(ctx) {
@@ -71,7 +66,52 @@ class GameMap {
   }
 
   get _map() {
-    return JSON.parse(this._dataset.map)
+    let map = {}
+
+    if (this._mapCache) {
+      map = this._mapCache
+    } else {
+      let mapElements = document.getElementsByClassName('js-map-data')
+
+      for (let elem of mapElements) {
+        let id = elem.getAttribute('id').replace('map_', '')
+        map[id] = elem.value
+      }
+
+      this._mapCache = map
+    }
+
+    return map
+  }
+
+  get _axes() {
+    let axes = []
+
+    if (this._axesCache.length === 0) {
+      // Get the axis data based on the current values of all the input boxes
+      let axisElements = document.getElementsByClassName('js-axis-data')
+      let axisObjects = {}
+
+      for (let elem of axisElements) {
+        let property = elem.getAttribute('id').replace('axis_', '')
+        let axisId = elem.dataset.id
+
+        if (!axisObjects[axisId]) {
+          axisObjects[axisId] = {}
+        }
+        axisObjects[axisId][property] = elem.value
+      }
+
+      for (let axis in axisObjects) {
+        axes.push(new Axis(axisObjects[axis]))
+      }
+
+      this._axesCache = axes
+    } else {
+      axes = this._axesCache
+    }
+
+    return axes
   }
 }
 

--- a/app/javascript/views/maps/show.js
+++ b/app/javascript/views/maps/show.js
@@ -1,7 +1,7 @@
 import { GameMap } from '../../components/game_map.js'
 
 $(document).on('turbolinks:load', function() {
-  var selector = 'map'
-  var gameMap = new GameMap(selector)
+  let selector = 'map'
+  let gameMap = new GameMap(selector)
   gameMap.addMap()
 })

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -4,4 +4,8 @@ class Map < ApplicationRecord
   def to_json
     MapSerializer.new(self).to_json
   end
+
+  def number_of_axes
+    axes.count
+  end
 end

--- a/app/views/axes/_form.html.erb
+++ b/app/views/axes/_form.html.erb
@@ -13,57 +13,57 @@
 
   <div class="field">
     <%= form.label :name %>
-    <%= form.text_field :name %>
+    <%= form.text_field :name, class: "js-axis-data", data: { id: axis.id } %>
   </div>
 
   <div class="field">
     <%= form.label :degrees %>
-    <%= form.number_field :degrees %>
+    <%= form.number_field :degrees, class: "js-axis-data", data: { id: axis.id } %>
   </div>
 
   <div class="field">
     <%= form.label :x_offset %>
-    <%= form.number_field :x_offset %>
+    <%= form.number_field :x_offset, class: "js-axis-data", data: { id: axis.id } %>
   </div>
 
   <div class="field">
     <%= form.label :y_offset %>
-    <%= form.number_field :y_offset %>
+    <%= form.number_field :y_offset, class: "js-axis-data", data: { id: axis.id } %>
   </div>
 
   <div class="field">
     <%= form.label :hex_diameter %>
-    <%= form.number_field :hex_diameter %>
+    <%= form.number_field :hex_diameter, class: "js-axis-data", data: { id: axis.id } %>
   </div>
 
   <div class="field">
     <%= form.label :map_width %>
-    <%= form.number_field :map_width %>
+    <%= form.number_field :map_width, class: "js-axis-data", data: { id: axis.id } %>
   </div>
 
   <div class="field">
     <%= form.label :map_height %>
-    <%= form.number_field :map_height %>
+    <%= form.number_field :map_height, class: "js-axis-data", data: { id: axis.id } %>
   </div>
 
   <div class="field">
     <%= form.label :dash_filled_length %>
-    <%= form.number_field :dash_filled_length %>
+    <%= form.number_field :dash_filled_length, class: "js-axis-data", data: { id: axis.id } %>
   </div>
 
   <div class="field">
     <%= form.label :dash_blank_length %>
-    <%= form.number_field :dash_blank_length %>
+    <%= form.number_field :dash_blank_length, class: "js-axis-data", data: { id: axis.id } %>
   </div>
 
   <div class="field">
     <%= form.label :color %>
-    <%= form.text_field :color %>
+    <%= form.text_field :color, class: "js-axis-data", data: { id: axis.id } %>
   </div>
 
   <div class="field">
     <%= form.label :map_id %>
-    <%= form.number_field :map_id %>
+    <%= form.number_field :map_id, class: "js-axis-data", data: { id: axis.id } %>
   </div>
 
   <div class="actions">

--- a/app/views/axes/_form.html.erb
+++ b/app/views/axes/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: axis) do |form| %>
+<%= form_with(model: axis, class: "js-axis-form", data: { selector: "js-#{dom_id(axis)}" }) do |form| %>
   <% if axis.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(axis.errors.count, "error") %> prohibited this axis from being saved:</h2>
@@ -13,57 +13,57 @@
 
   <div class="field">
     <%= form.label :name %>
-    <%= form.text_field :name, class: "js-axis-data", data: { id: axis.id } %>
+    <%= form.text_field :name, class: "js-#{dom_id(axis)}" %>
   </div>
 
   <div class="field">
     <%= form.label :degrees %>
-    <%= form.number_field :degrees, class: "js-axis-data", data: { id: axis.id } %>
+    <%= form.number_field :degrees, class: "js-#{dom_id(axis)}" %>
   </div>
 
   <div class="field">
     <%= form.label :x_offset %>
-    <%= form.number_field :x_offset, class: "js-axis-data", data: { id: axis.id } %>
+    <%= form.number_field :x_offset, class: "js-#{dom_id(axis)}" %>
   </div>
 
   <div class="field">
     <%= form.label :y_offset %>
-    <%= form.number_field :y_offset, class: "js-axis-data", data: { id: axis.id } %>
+    <%= form.number_field :y_offset, class: "js-#{dom_id(axis)}" %>
   </div>
 
   <div class="field">
     <%= form.label :hex_diameter %>
-    <%= form.number_field :hex_diameter, class: "js-axis-data", data: { id: axis.id } %>
+    <%= form.number_field :hex_diameter, class: "js-#{dom_id(axis)}" %>
   </div>
 
   <div class="field">
     <%= form.label :map_width %>
-    <%= form.number_field :map_width, class: "js-axis-data", data: { id: axis.id } %>
+    <%= form.number_field :map_width, class: "js-#{dom_id(axis)}" %>
   </div>
 
   <div class="field">
     <%= form.label :map_height %>
-    <%= form.number_field :map_height, class: "js-axis-data", data: { id: axis.id } %>
+    <%= form.number_field :map_height, class: "js-#{dom_id(axis)}" %>
   </div>
 
   <div class="field">
     <%= form.label :dash_filled_length %>
-    <%= form.number_field :dash_filled_length, class: "js-axis-data", data: { id: axis.id } %>
+    <%= form.number_field :dash_filled_length, class: "js-#{dom_id(axis)}" %>
   </div>
 
   <div class="field">
     <%= form.label :dash_blank_length %>
-    <%= form.number_field :dash_blank_length, class: "js-axis-data", data: { id: axis.id } %>
+    <%= form.number_field :dash_blank_length, class: "js-#{dom_id(axis)}" %>
   </div>
 
   <div class="field">
     <%= form.label :color %>
-    <%= form.text_field :color, class: "js-axis-data", data: { id: axis.id } %>
+    <%= form.text_field :color, class: "js-#{dom_id(axis)}" %>
   </div>
 
   <div class="field">
     <%= form.label :map_id %>
-    <%= form.number_field :map_id, class: "js-axis-data", data: { id: axis.id } %>
+    <%= form.number_field :map_id, class: "js-#{dom_id(axis)}" %>
   </div>
 
   <div class="actions">

--- a/app/views/maps/_form.html.erb
+++ b/app/views/maps/_form.html.erb
@@ -13,17 +13,17 @@
 
   <div class="field">
     <%= form.label :background %>
-    <%= form.text_field :background %>
+    <%= form.text_field :background, class: "js-map-data" %>
   </div>
 
   <div class="field">
     <%= form.label :x %>
-    <%= form.number_field :x %>
+    <%= form.number_field :x, class: "js-map-data" %>
   </div>
 
   <div class="field">
     <%= form.label :y %>
-    <%= form.number_field :y %>
+    <%= form.number_field :y, class: "js-map-data" %>
   </div>
 
   <div class="field">

--- a/app/views/maps/_form.html.erb
+++ b/app/views/maps/_form.html.erb
@@ -31,6 +31,10 @@
     <%= form.number_field :z %>
   </div>
 
+  <div class="field">
+    <%= form.hidden_field :number_of_axes, class: "js-map-data" %>
+  </div>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/maps/show.html.erb
+++ b/app/views/maps/show.html.erb
@@ -10,7 +10,7 @@
   </div>
   <div class="row">
     <div class="col-md-9 pre-scrollable map-view">
-      <div id="map" class="w-100 h-100" <%= "data-map=#{@map.to_json}" %>></div>
+      <div id="map" class="w-100 h-100"></div>
     </div>
     <div class="col-md-3">
       <%= render partial: "controls" %>


### PR DESCRIPTION
This PR updates the axis controls and map. The axes will now redraw automatically when the values change. They will only persist when the `Update Axis`button is clicked. Auto updating will be implemented later.

The map and axes now get their values from the input boxes instead of the map element's JSON, and the map's JSON data has been removed.

Tests will be updates in a future PR.

[Map show page with controls](https://user-images.githubusercontent.com/7622382/90313707-99a32a00-dedc-11ea-9e00-62e7b03dd7cf.png)
