### PR TITLE
Update schema, replace x y z from map with width height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+.env

--- a/app/views/maps/show.html.erb
+++ b/app/views/maps/show.html.erb
@@ -4,7 +4,7 @@
   <div class="row">
     <div class="col-12">
       <small>
-        <%= link_to "#{@map.background} #{@map.x}x#{@map.y}x#{@map.z}", edit_map_path(@map) %>
+        <%= link_to "#{@map.background} #{@map.width}x#{@map.height}", edit_map_path(@map) %>
       </small>
     </div>
   </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_12_180442) do
+ActiveRecord::Schema.define(version: 2020_08_16_000716) do
 
   create_table "axes", force: :cascade do |t|
     t.string "name"
@@ -64,9 +64,8 @@ ActiveRecord::Schema.define(version: 2020_07_12_180442) do
 
   create_table "maps", force: :cascade do |t|
     t.string "background"
-    t.integer "x"
-    t.integer "y"
-    t.integer "z"
+    t.integer "width"
+    t.integer "height"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,7 @@ hexes = [{ id: 1, name: "Desert", x: 0, y: 0, z: 0, background: "desert.png", cr
 
 hexes.each { |hex| Hex.create(hex) }
 
-maps = [{ id: 1, background: "tim.jpg", x: 800, y: 800, z: 1, created_at: "2020-06-10 19:49:43", updated_at: "2020-06-10 22:21:23" }]
+maps = [{ id: 1, background: "tim.jpg", width: 800, height: 800, created_at: "2020-06-10 19:49:43", updated_at: "2020-06-10 22:21:23" }]
 
 maps.each { |map| Map.create(map) }
 


### PR DESCRIPTION
This commit updates the schema and seed file to use width and height for
map instead of x y and z.